### PR TITLE
[codex] Add dashboard and one-off run queue

### DIFF
--- a/ruta/irrigate/forms.py
+++ b/ruta/irrigate/forms.py
@@ -1,0 +1,30 @@
+from django import forms
+
+from irrigate.models import Actuator, ActuatorRunLog
+
+
+MAX_ONE_OFF_DURATION_IN_MINUTES = 120
+
+
+class OneOffRunForm(forms.Form):
+    actuator = forms.ModelChoiceField(
+        queryset=Actuator.objects.order_by("name"),
+        empty_label="Select a zone",
+    )
+    duration_in_minutes = forms.IntegerField(
+        min_value=1,
+        max_value=MAX_ONE_OFF_DURATION_IN_MINUTES,
+        widget=forms.NumberInput(
+            attrs={"min": 1, "max": MAX_ONE_OFF_DURATION_IN_MINUTES}
+        ),
+    )
+
+    def clean_actuator(self):
+        actuator = self.cleaned_data["actuator"]
+        is_running = ActuatorRunLog.objects.filter(
+            actuator=actuator,
+            end_datetime__isnull=True,
+        ).exists()
+        if is_running:
+            raise forms.ValidationError("This zone is already running.")
+        return actuator

--- a/ruta/irrigate/static/irrigate/css/dashboard.css
+++ b/ruta/irrigate/static/irrigate/css/dashboard.css
@@ -1,27 +1,344 @@
-.run-table {
-	max-width: 980px;
-	margin: 0 auto;
-	padding: 0 16px;
+* {
+	box-sizing: border-box;
 }
 
-.dashboard-header {
+body {
+	background: #f5f7f3;
+	color: #1f2933;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.dashboard-shell {
+	margin: 0 auto;
+	max-width: 1180px;
+	padding: 32px 20px 48px;
+}
+
+.dashboard-header,
+.section-heading,
+.dashboard-tool {
 	align-items: center;
 	display: flex;
-	gap: 16px;
+	gap: 18px;
 	justify-content: space-between;
 }
 
-.logout-link {
-	border: 1px solid #c6d0dc;
-	border-radius: 4px;
-	color: #1a5b7a;
+.dashboard-header {
+	margin-bottom: 24px;
+}
+
+.dashboard-header h1,
+.dashboard-section h2,
+.dashboard-tool h2 {
+	margin: 0;
+}
+
+.dashboard-header h1 {
+	font-size: 38px;
+	line-height: 1.05;
+}
+
+.dashboard-section h2,
+.dashboard-tool h2 {
+	font-size: 22px;
+	line-height: 1.2;
+}
+
+.eyebrow {
+	color: #5d6f62;
+	font-size: 12px;
+	font-weight: 700;
+	letter-spacing: 0;
+	margin: 0 0 6px;
+	text-transform: uppercase;
+}
+
+.header-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+	justify-content: flex-end;
+}
+
+.secondary-link,
+.pagination a,
+.pagination span,
+.pagination strong {
+	align-items: center;
+	border: 1px solid #cbd7ce;
+	border-radius: 6px;
+	color: #1c5f70;
+	display: inline-flex;
+	min-height: 40px;
 	padding: 8px 12px;
 	text-decoration: none;
 	white-space: nowrap;
 }
 
-.logout-link:hover,
-.logout-link:focus {
-	background: #edf6f9;
-	border-color: #7fb0c3;
+.secondary-link:hover,
+.secondary-link:focus,
+.pagination a:hover,
+.pagination a:focus {
+	background: #e8f3ee;
+	border-color: #8eb9a5;
+}
+
+.messages {
+	display: grid;
+	gap: 10px;
+	margin-bottom: 20px;
+}
+
+.message {
+	border: 1px solid #cbd7ce;
+	border-radius: 6px;
+	margin: 0;
+	padding: 12px 14px;
+}
+
+.message-success {
+	background: #e7f6ec;
+	border-color: #91caa2;
+	color: #245833;
+}
+
+.message-error {
+	background: #fff0ed;
+	border-color: #e0a092;
+	color: #8c2f24;
+}
+
+.summary-grid {
+	display: grid;
+	gap: 14px;
+	grid-template-columns: repeat(4, minmax(0, 1fr));
+	margin-bottom: 18px;
+}
+
+.summary-card {
+	background: #ffffff;
+	border: 1px solid #d7dfd8;
+	border-radius: 8px;
+	display: grid;
+	gap: 8px;
+	min-height: 128px;
+	padding: 18px;
+}
+
+.summary-card strong {
+	color: #17373d;
+	display: block;
+	font-size: 28px;
+	line-height: 1.1;
+	overflow-wrap: anywhere;
+}
+
+.summary-card span:last-child {
+	color: #65736c;
+	line-height: 1.4;
+}
+
+.summary-label {
+	color: #5b6b64;
+	font-size: 13px;
+	font-weight: 700;
+}
+
+.dashboard-tool {
+	background: #ffffff;
+	border: 1px solid #cad8d7;
+	border-radius: 8px;
+	margin-bottom: 30px;
+	padding: 20px;
+}
+
+.one-off-form {
+	align-items: end;
+	display: grid;
+	gap: 12px;
+	grid-template-columns: minmax(180px, 1fr) 140px auto;
+	min-width: min(100%, 620px);
+}
+
+.one-off-form label {
+	color: #536158;
+	display: grid;
+	font-size: 13px;
+	font-weight: 700;
+	gap: 6px;
+}
+
+.one-off-form select,
+.one-off-form input {
+	background: #fbfcfb;
+	border: 1px solid #bccbc5;
+	border-radius: 6px;
+	color: #1f2933;
+	min-height: 42px;
+	padding: 8px 10px;
+	width: 100%;
+}
+
+.one-off-form button {
+	background: #216e5f;
+	border: 1px solid #216e5f;
+	border-radius: 6px;
+	color: #ffffff;
+	cursor: pointer;
+	font-weight: 700;
+	min-height: 42px;
+	padding: 8px 16px;
+	white-space: nowrap;
+}
+
+.one-off-form button:hover,
+.one-off-form button:focus {
+	background: #18584b;
+	border-color: #18584b;
+}
+
+.dashboard-section {
+	border-top: 1px solid #d7dfd8;
+	margin-top: 26px;
+	padding-top: 24px;
+}
+
+.section-heading {
+	margin-bottom: 12px;
+}
+
+.table-wrap {
+	overflow-x: auto;
+}
+
+.dashboard-table {
+	background: #ffffff;
+	border-collapse: collapse;
+	border: 1px solid #d7dfd8;
+	border-radius: 8px;
+	overflow: hidden;
+	width: 100%;
+}
+
+.dashboard-table th,
+.dashboard-table td {
+	border-bottom: 1px solid #e3e8e3;
+	padding: 13px 14px;
+	text-align: left;
+	vertical-align: top;
+}
+
+.dashboard-table th {
+	background: #eef3ef;
+	color: #4e5f55;
+	font-size: 12px;
+	font-weight: 800;
+	text-transform: uppercase;
+	white-space: nowrap;
+}
+
+.dashboard-table tr:last-child td {
+	border-bottom: 0;
+}
+
+.empty-state {
+	background: #ffffff;
+	border: 1px dashed #bdcbbf;
+	border-radius: 8px;
+	color: #647168;
+	margin: 0;
+	padding: 18px;
+}
+
+.status-badge {
+	border-radius: 999px;
+	display: inline-flex;
+	font-size: 12px;
+	font-weight: 800;
+	line-height: 1;
+	padding: 7px 9px;
+	text-transform: uppercase;
+	white-space: nowrap;
+}
+
+.status-running {
+	background: #fff4cf;
+	color: #765214;
+}
+
+.status-finished {
+	background: #e5f4ef;
+	color: #1f644f;
+}
+
+.status-skipped {
+	background: #edf0f4;
+	color: #4a5663;
+}
+
+.pagination {
+	align-items: center;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+	justify-content: flex-end;
+	margin-top: 14px;
+}
+
+.pagination span {
+	color: #8a958f;
+}
+
+.pagination strong {
+	background: #ffffff;
+	color: #536158;
+	font-weight: 700;
+}
+
+@media (max-width: 900px) {
+	.summary-grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.dashboard-tool {
+		align-items: stretch;
+		display: grid;
+	}
+
+	.one-off-form {
+		min-width: 0;
+	}
+}
+
+@media (max-width: 640px) {
+	.dashboard-shell {
+		padding: 22px 14px 36px;
+	}
+
+	.dashboard-header,
+	.section-heading {
+		align-items: flex-start;
+		display: grid;
+	}
+
+	.header-actions {
+		justify-content: flex-start;
+	}
+
+	.dashboard-header h1 {
+		font-size: 32px;
+	}
+
+	.summary-grid,
+	.one-off-form {
+		grid-template-columns: 1fr;
+	}
+
+	.dashboard-table {
+		min-width: 680px;
+	}
+
+	.pagination {
+		justify-content: flex-start;
+	}
 }

--- a/ruta/irrigate/templates/irrigate/dashboard.html
+++ b/ruta/irrigate/templates/irrigate/dashboard.html
@@ -5,42 +5,247 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<title>Ruta Dashboard</title>
 		<link rel="stylesheet" type="text/css" href="{% static 'irrigate/css/base.css' %}">
 		<link rel="stylesheet" type="text/css" href="{% static 'irrigate/css/dashboard.css' %}">
 	</head>
 
 	<body>
-		<div class="l-content run-table">
+		<main class="dashboard-shell">
 			<header class="dashboard-header">
-				<h1>Recent sprinkler runs</h1>
-				<a class="logout-link" href="{% url 'logout' %}">Log out</a>
+				<div>
+					<p class="eyebrow">Irrigation Control</p>
+					<h1>Sprinklers</h1>
+				</div>
+				<nav class="header-actions" aria-label="Dashboard links">
+					<a class="secondary-link" href="{% url 'admin:index' %}">Admin</a>
+					<a class="secondary-link" href="{% url 'logout' %}">Log out</a>
+				</nav>
 			</header>
 
-
-			{% if runs %}
-			<table class="pure-table pure-table-bordered">
-				<thead>
-					<tr>
-						<th>Name</th>
-						<th>Time</th>
-						<th>Duration</th>
-						<th>Status</th>
-					</tr>
-				</thead>
-				<tbody>
-					{% for run in runs %}
-					<tr>
-						<td>{{ run.actuator.name }}</td>
-						<td>{{ run.start_datetime }}</td>
-						<td>{{ run.duration_in_minutes }}</td>
-						<td>{{ run.status }}</td>
-					</tr>
-					{% endfor %}
-				</tbody>
-			</table>
-			{% else %}
-			<div class="pure-u-1-1"><p>No runs available</div>
+			{% if messages %}
+			<div class="messages" role="status">
+				{% for message in messages %}
+				<p class="message message-{{ message.tags }}">{{ message }}</p>
+				{% endfor %}
+			</div>
 			{% endif %}
-		</div>
+
+			<section class="summary-grid" aria-label="Sprinkler summary">
+				<article class="summary-card">
+					<span class="summary-label">Running now</span>
+					<strong>{{ running_runs|length }}</strong>
+					<span>
+						{% if running_runs %}
+						{% for run in running_runs %}{{ run.actuator.name }}{% if not forloop.last %}, {% endif %}{% endfor %}
+						{% else %}
+						No active zones
+						{% endif %}
+					</span>
+				</article>
+				<article class="summary-card">
+					<span class="summary-label">Queued one-offs</span>
+					<strong>{{ queued_one_offs|length }}</strong>
+					<span>Waiting for the scheduler</span>
+				</article>
+				<article class="summary-card">
+					<span class="summary-label">Next recurring</span>
+					<strong>
+						{% if next_recurring_schedule %}
+						{{ next_recurring_schedule.get_weekday_display }}
+						{% else %}
+						None
+						{% endif %}
+					</strong>
+					<span>
+						{% if next_recurring_schedule %}
+						{{ next_recurring_schedule.start_time|time:"g:i A" }}
+						{% else %}
+						No enabled schedule
+						{% endif %}
+					</span>
+				</article>
+				<article class="summary-card">
+					<span class="summary-label">Recent activity</span>
+					<strong>
+						{% if recent_run %}
+						{{ recent_run.actuator.name }}
+						{% else %}
+						None
+						{% endif %}
+					</strong>
+					<span>
+						{% if recent_run %}
+						{{ recent_run.start_datetime|date:"M j, g:i A" }}
+						{% else %}
+						No runs logged
+						{% endif %}
+					</span>
+				</article>
+			</section>
+
+			<section class="dashboard-tool" aria-labelledby="one-off-title">
+				<div>
+					<p class="eyebrow">Manual run</p>
+					<h2 id="one-off-title">Queue a one-off run</h2>
+				</div>
+				<form class="one-off-form" action="{% url 'one_off_run' %}" method="post">
+					{% csrf_token %}
+					<label>
+						<span>Zone</span>
+						{{ one_off_form.actuator }}
+					</label>
+					<label>
+						<span>Minutes</span>
+						{{ one_off_form.duration_in_minutes }}
+					</label>
+					<button type="submit">Queue run</button>
+				</form>
+			</section>
+
+			<section class="dashboard-section" aria-labelledby="queued-title">
+				<div class="section-heading">
+					<div>
+						<p class="eyebrow">Manual queue</p>
+						<h2 id="queued-title">Queued one-off runs</h2>
+					</div>
+				</div>
+
+				{% if queued_one_offs %}
+				<div class="table-wrap">
+					<table class="dashboard-table">
+						<thead>
+							<tr>
+								<th>Zone</th>
+								<th>Queued for</th>
+								<th>Created</th>
+							</tr>
+						</thead>
+						<tbody>
+							{% for schedule in queued_one_offs %}
+							<tr>
+								<td>
+									{% for actuator in schedule.actuators.all %}
+									{{ actuator.name }}{% if not forloop.last %}, {% endif %}
+									{% endfor %}
+								</td>
+								<td>{{ schedule.duration_in_minutes|floatformat:"-2" }} min</td>
+								<td>{{ schedule.get_weekday_display }} at {{ schedule.start_time|time:"g:i A" }}</td>
+							</tr>
+							{% endfor %}
+						</tbody>
+					</table>
+				</div>
+				{% else %}
+				<p class="empty-state">No one-off runs are queued.</p>
+				{% endif %}
+			</section>
+
+			<section class="dashboard-section" aria-labelledby="schedule-title">
+				<div class="section-heading">
+					<div>
+						<p class="eyebrow">Recurring</p>
+						<h2 id="schedule-title">Schedule</h2>
+					</div>
+				</div>
+
+				{% if recurring_schedules %}
+				<div class="table-wrap">
+					<table class="dashboard-table">
+						<thead>
+							<tr>
+								<th>Day</th>
+								<th>Time</th>
+								<th>Zones</th>
+								<th>Duration</th>
+							</tr>
+						</thead>
+						<tbody>
+							{% for schedule in recurring_schedules %}
+							<tr>
+								<td>{{ schedule.get_weekday_display }}</td>
+								<td>{{ schedule.start_time|time:"g:i A" }}</td>
+								<td>
+									{% for actuator in schedule.actuators.all %}
+									{{ actuator.name }}{% if not forloop.last %}, {% endif %}
+									{% endfor %}
+								</td>
+								<td>
+									{% if schedule.duration_in_minutes %}
+									{{ schedule.duration_in_minutes|floatformat:"-2" }} min
+									{% else %}
+									Calculated
+									{% endif %}
+								</td>
+							</tr>
+							{% endfor %}
+						</tbody>
+					</table>
+				</div>
+				{% else %}
+				<p class="empty-state">No enabled recurring schedules.</p>
+				{% endif %}
+			</section>
+
+			<section class="dashboard-section" aria-labelledby="runs-title">
+				<div class="section-heading">
+					<div>
+						<p class="eyebrow">History</p>
+						<h2 id="runs-title">Recent runs</h2>
+					</div>
+				</div>
+
+				{% if runs %}
+				<div class="table-wrap">
+					<table class="dashboard-table">
+						<thead>
+							<tr>
+								<th>Zone</th>
+								<th>Run type</th>
+								<th>Started</th>
+								<th>Duration</th>
+								<th>Status</th>
+							</tr>
+						</thead>
+						<tbody>
+							{% for run in runs %}
+							<tr>
+								<td>{{ run.actuator.name }}</td>
+								<td>
+									{% if run.schedule_time %}
+									{{ run.schedule_time.get_run_type_display }}
+									{% else %}
+									Manual
+									{% endif %}
+								</td>
+								<td>{{ run.start_datetime|date:"M j, g:i A" }}</td>
+								<td>{{ run.duration_in_minutes|floatformat:"-2" }} min</td>
+								<td><span class="status-badge status-{{ run.status }}">{{ run.status }}</span></td>
+							</tr>
+							{% endfor %}
+						</tbody>
+					</table>
+				</div>
+
+				{% if is_paginated %}
+				<nav class="pagination" aria-label="Recent run pages">
+					{% if page_obj.has_previous %}
+					<a href="?page={{ page_obj.previous_page_number }}">Previous</a>
+					{% else %}
+					<span>Previous</span>
+					{% endif %}
+					<strong>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</strong>
+					{% if page_obj.has_next %}
+					<a href="?page={{ page_obj.next_page_number }}">Next</a>
+					{% else %}
+					<span>Next</span>
+					{% endif %}
+				</nav>
+				{% endif %}
+				{% else %}
+				<p class="empty-state">No runs available.</p>
+				{% endif %}
+			</section>
+		</main>
 	</body>
 </html>

--- a/ruta/irrigate/tests/test_models.py
+++ b/ruta/irrigate/tests/test_models.py
@@ -15,6 +15,9 @@ class ActuatorTests(TestCase):
         self.actuator.get_forecasted_precipitation_from_rain_in_inches = Mock(
             return_value=0
         )
+        self.actuator.get_temperature_watering_adjustment_multiplier = Mock(
+            return_value=1
+        )
 
     def test_get_duration_in_seconds(self):
         self.actuator.get_recent_water_amount_in_inches = Mock(return_value=0.67)

--- a/ruta/irrigate/tests/test_views.py
+++ b/ruta/irrigate/tests/test_views.py
@@ -1,6 +1,11 @@
+from datetime import time, timedelta
+
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
+from django.utils import timezone
+
+from irrigate.models import Actuator, ActuatorRunLog, Device, ScheduleTime
 
 
 class DashboardAuthTests(TestCase):
@@ -9,6 +14,13 @@ class DashboardAuthTests(TestCase):
 
         self.assertRedirects(
             response, f"{reverse('login')}?next={reverse('dashboard')}"
+        )
+
+    def test_one_off_run_requires_login(self):
+        response = self.client.post(reverse("one_off_run"))
+
+        self.assertRedirects(
+            response, f"{reverse('login')}?next={reverse('one_off_run')}"
         )
 
     def test_dashboard_renders_for_authenticated_user(self):
@@ -33,3 +45,120 @@ class DashboardAuthTests(TestCase):
         )
 
         self.assertRedirects(response, reverse("dashboard"))
+
+
+class DashboardTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="ruta", password="correct-password"
+        )
+        self.client.force_login(self.user)
+        self.device = Device.objects.create(name="device")
+        self.actuator = Actuator.objects.create(
+            name="Front Yard", gpio_pin=5, device=self.device
+        )
+
+    def test_dashboard_includes_schedule_queue_and_paginated_runs(self):
+        recurring_schedule = ScheduleTime.objects.create(
+            run_type=ScheduleTime.RunType.RECURRING,
+            weekday=ScheduleTime.Weekday.MONDAY,
+            start_time=time(6, 0),
+        )
+        recurring_schedule.actuators.add(self.actuator)
+        queued_one_off = ScheduleTime.objects.create(
+            run_type=ScheduleTime.RunType.ONE_OFF,
+            weekday=ScheduleTime.Weekday.MONDAY,
+            start_time=time(7, 0),
+            duration_in_minutes=10,
+        )
+        queued_one_off.actuators.add(self.actuator)
+
+        now = timezone.now()
+        for index in range(30):
+            start_datetime = now - timedelta(minutes=index)
+            ActuatorRunLog.objects.create(
+                actuator=self.actuator,
+                start_datetime=start_datetime,
+                end_datetime=start_datetime + timedelta(minutes=5),
+            )
+
+        response = self.client.get(reverse("dashboard"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            list(response.context["recurring_schedules"]), [recurring_schedule]
+        )
+        self.assertEqual(list(response.context["queued_one_offs"]), [queued_one_off])
+        self.assertTrue(response.context["is_paginated"])
+        self.assertEqual(len(response.context["runs"]), 25)
+        self.assertContains(response, "Front Yard")
+        self.assertContains(response, "Queued one-off runs")
+        self.assertContains(response, "Schedule")
+        self.assertContains(response, "Page 1 of 2")
+
+    def test_dashboard_excludes_one_offs_that_already_have_a_run(self):
+        completed_one_off = ScheduleTime.objects.create(
+            run_type=ScheduleTime.RunType.ONE_OFF,
+            weekday=ScheduleTime.Weekday.MONDAY,
+            start_time=time(7, 0),
+            duration_in_minutes=10,
+        )
+        completed_one_off.actuators.add(self.actuator)
+        ActuatorRunLog.objects.create(
+            actuator=self.actuator,
+            schedule_time=completed_one_off,
+            start_datetime=timezone.now(),
+            end_datetime=timezone.now() + timedelta(minutes=10),
+        )
+
+        response = self.client.get(reverse("dashboard"))
+
+        self.assertEqual(list(response.context["queued_one_offs"]), [])
+
+    def test_one_off_run_post_creates_queued_schedule(self):
+        response = self.client.post(
+            reverse("one_off_run"),
+            {
+                "actuator": self.actuator.id,
+                "duration_in_minutes": 12,
+            },
+        )
+
+        self.assertRedirects(response, reverse("dashboard"))
+        schedule_time = ScheduleTime.objects.get(run_type=ScheduleTime.RunType.ONE_OFF)
+        self.assertTrue(schedule_time.enabled)
+        self.assertEqual(schedule_time.duration_in_minutes, 12)
+        self.assertEqual(schedule_time.actuators.get(), self.actuator)
+
+    def test_one_off_run_rejects_invalid_duration(self):
+        response = self.client.post(
+            reverse("one_off_run"),
+            {
+                "actuator": self.actuator.id,
+                "duration_in_minutes": 121,
+            },
+        )
+
+        self.assertRedirects(response, reverse("dashboard"))
+        self.assertFalse(
+            ScheduleTime.objects.filter(run_type=ScheduleTime.RunType.ONE_OFF).exists()
+        )
+
+    def test_one_off_run_rejects_running_actuator(self):
+        ActuatorRunLog.objects.create(
+            actuator=self.actuator,
+            start_datetime=timezone.now(),
+        )
+
+        response = self.client.post(
+            reverse("one_off_run"),
+            {
+                "actuator": self.actuator.id,
+                "duration_in_minutes": 10,
+            },
+        )
+
+        self.assertRedirects(response, reverse("dashboard"))
+        self.assertFalse(
+            ScheduleTime.objects.filter(run_type=ScheduleTime.RunType.ONE_OFF).exists()
+        )

--- a/ruta/irrigate/urls.py
+++ b/ruta/irrigate/urls.py
@@ -4,4 +4,5 @@ from irrigate import views
 
 urlpatterns = [
     path("", views.DashboardView.as_view(), name="dashboard"),
+    path("runs/one-off/", views.OneOffRunView.as_view(), name="one_off_run"),
 ]

--- a/ruta/irrigate/views.py
+++ b/ruta/irrigate/views.py
@@ -1,12 +1,106 @@
+from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.shortcuts import redirect
+from django.utils import timezone
 from django.views import generic
 
-from irrigate.models import ActuatorRunLog
+from irrigate.forms import OneOffRunForm
+from irrigate.models import ActuatorRunLog, ScheduleTime
 
 
 class DashboardView(LoginRequiredMixin, generic.ListView):
     template_name = "irrigate/dashboard.html"
     context_object_name = "runs"
+    paginate_by = 25
 
     def get_queryset(self):
-        return ActuatorRunLog.objects.all()[:100]
+        return ActuatorRunLog.objects.select_related("actuator", "schedule_time")
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        running_runs = ActuatorRunLog.objects.select_related(
+            "actuator", "schedule_time"
+        ).filter(end_datetime__isnull=True)
+        completed_schedule_ids = ActuatorRunLog.objects.filter(
+            schedule_time_id__isnull=False
+        ).values("schedule_time_id")
+        queued_one_offs = (
+            ScheduleTime.objects.prefetch_related("actuators")
+            .filter(
+                enabled=True,
+                run_type=ScheduleTime.RunType.ONE_OFF,
+            )
+            .exclude(id__in=completed_schedule_ids)
+            .order_by("-id")
+        )
+        recurring_schedules = list(
+            ScheduleTime.objects.prefetch_related("actuators")
+            .filter(
+                enabled=True,
+                run_type=ScheduleTime.RunType.RECURRING,
+            )
+            .order_by("weekday", "start_time", "id")
+        )
+
+        context.update(
+            {
+                "one_off_form": OneOffRunForm(),
+                "running_runs": running_runs,
+                "queued_one_offs": queued_one_offs,
+                "recurring_schedules": recurring_schedules,
+                "recent_run": ActuatorRunLog.objects.select_related(
+                    "actuator", "schedule_time"
+                ).first(),
+                "next_recurring_schedule": self._get_next_recurring_schedule(
+                    recurring_schedules
+                ),
+            }
+        )
+        return context
+
+    def _get_next_recurring_schedule(self, recurring_schedules):
+        if not recurring_schedules:
+            return None
+
+        now = timezone.localtime()
+        current_weekday = now.weekday()
+        current_time = now.time()
+
+        def sort_key(schedule_time):
+            days_ahead = (schedule_time.weekday - current_weekday) % 7
+            if days_ahead == 0 and schedule_time.start_time <= current_time:
+                days_ahead = 7
+            return days_ahead, schedule_time.start_time, schedule_time.id
+
+        return min(recurring_schedules, key=sort_key)
+
+
+class OneOffRunView(LoginRequiredMixin, generic.View):
+    http_method_names = ["post"]
+
+    def post(self, request, *args, **kwargs):
+        form = OneOffRunForm(request.POST)
+        if form.is_valid():
+            now = timezone.localtime()
+            actuator = form.cleaned_data["actuator"]
+            duration_in_minutes = form.cleaned_data["duration_in_minutes"]
+            schedule_time = ScheduleTime.objects.create(
+                enabled=True,
+                run_type=ScheduleTime.RunType.ONE_OFF,
+                weekday=now.weekday(),
+                start_time=now.time(),
+                duration_in_minutes=duration_in_minutes,
+            )
+            schedule_time.actuators.add(actuator)
+
+            minute_label = "minute" if duration_in_minutes == 1 else "minutes"
+            messages.success(
+                request,
+                f"Queued {actuator.name} for {duration_in_minutes} {minute_label}.",
+            )
+        else:
+            for errors in form.errors.values():
+                for error in errors:
+                    messages.error(request, error)
+
+        return redirect("dashboard")


### PR DESCRIPTION
## Summary
- Redesign the authenticated home page into a sprinkler dashboard with running zones, queued one-offs, recurring schedule, and paginated run history.
- Add a login-protected one-off run POST flow that creates `ScheduleTime(run_type=ONE_OFF)` rows for the existing scheduler to pick up.
- Add view coverage for dashboard context, pagination, one-off creation, invalid duration, and active-zone rejection.

## Validation
- `RUTA_SECRET_KEY=test-secret-key make test`