### PR TITLE
[codex] Expose grass seed mode on dashboard

### DIFF
--- a/ruta/irrigate/schedule.py
+++ b/ruta/irrigate/schedule.py
@@ -12,8 +12,9 @@ logger = logging.getLogger(__name__)
 
 # Constants for grass seed mode
 GRASS_SEED_DURATION_SECONDS = 300  # 5 minutes
-GRASS_SEED_MORNING_HOUR = 10  # 6 AM ET
-GRASS_SEED_EVENING_HOUR = 24  # 8 PM ET
+GRASS_SEED_MORNING_HOUR = 10
+GRASS_SEED_EVENING_HOUR = 0
+GRASS_SEED_RUN_HOURS = (GRASS_SEED_MORNING_HOUR, GRASS_SEED_EVENING_HOUR)
 
 
 def _run(
@@ -118,10 +119,7 @@ def run_all(dry_run: bool = False) -> List[Actuator]:
 
     # Now handle grass seed mode actuators - they run twice daily for 5 minutes
     current_hour = now.hour
-    if current_hour in [
-        GRASS_SEED_MORNING_HOUR,
-        GRASS_SEED_EVENING_HOUR,
-    ]:  # Run at 6 AM and 6 PM
+    if current_hour in GRASS_SEED_RUN_HOURS:
         grass_seed_actuators = Actuator.objects.filter(grass_seed_mode=True)
         logger.info(
             f"Found {grass_seed_actuators.count()} actuators in grass seed mode"

--- a/ruta/irrigate/static/irrigate/css/dashboard.css
+++ b/ruta/irrigate/static/irrigate/css/dashboard.css
@@ -111,7 +111,7 @@ body {
 .summary-grid {
 	display: grid;
 	gap: 14px;
-	grid-template-columns: repeat(4, minmax(0, 1fr));
+	grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 	margin-bottom: 18px;
 }
 
@@ -207,6 +207,52 @@ body {
 	margin-bottom: 12px;
 }
 
+.section-meta {
+	color: #65736c;
+	line-height: 1.4;
+	margin: 0;
+	text-align: right;
+}
+
+.run-window-list {
+	display: grid;
+	gap: 4px;
+}
+
+.inline-action-form {
+	margin: 0;
+}
+
+.toggle-button {
+	background: #216e5f;
+	border: 1px solid #216e5f;
+	border-radius: 6px;
+	color: #ffffff;
+	cursor: pointer;
+	font-weight: 700;
+	min-height: 36px;
+	padding: 7px 12px;
+	white-space: nowrap;
+}
+
+.toggle-button:hover,
+.toggle-button:focus {
+	background: #18584b;
+	border-color: #18584b;
+}
+
+.toggle-button-secondary {
+	background: #ffffff;
+	border-color: #bccbc5;
+	color: #1c5f70;
+}
+
+.toggle-button-secondary:hover,
+.toggle-button-secondary:focus {
+	background: #e8f3ee;
+	border-color: #8eb9a5;
+}
+
 .table-wrap {
 	overflow-x: auto;
 }
@@ -276,6 +322,16 @@ body {
 	color: #4a5663;
 }
 
+.status-enabled {
+	background: #e5f4ef;
+	color: #1f644f;
+}
+
+.status-disabled {
+	background: #edf0f4;
+	color: #4a5663;
+}
+
 .pagination {
 	align-items: center;
 	display: flex;
@@ -319,6 +375,10 @@ body {
 	.section-heading {
 		align-items: flex-start;
 		display: grid;
+	}
+
+	.section-meta {
+		text-align: left;
 	}
 
 	.header-actions {

--- a/ruta/irrigate/templates/irrigate/dashboard.html
+++ b/ruta/irrigate/templates/irrigate/dashboard.html
@@ -50,6 +50,17 @@
 					<span>Waiting for the scheduler</span>
 				</article>
 				<article class="summary-card">
+					<span class="summary-label">Grass seed mode</span>
+					<strong>{{ grass_seed_enabled_count }}</strong>
+					<span>
+						{% if grass_seed_enabled_count == 1 %}
+						Zone enabled
+						{% else %}
+						Zones enabled
+						{% endif %}
+					</span>
+				</article>
+				<article class="summary-card">
 					<span class="summary-label">Next recurring</span>
 					<strong>
 						{% if next_recurring_schedule %}
@@ -102,6 +113,73 @@
 					</label>
 					<button type="submit">Queue run</button>
 				</form>
+			</section>
+
+			<section class="dashboard-section" aria-labelledby="grass-seed-title">
+				<div class="section-heading">
+					<div>
+						<p class="eyebrow">Growth mode</p>
+						<h2 id="grass-seed-title">Grass seed mode</h2>
+					</div>
+					<p class="section-meta">
+						{% for run_datetime in grass_seed_run_datetimes %}
+						<time datetime="{{ run_datetime|date:"c" }}" data-dashboard-format="weekday-time">{{ run_datetime|date:"l, g:i A" }}</time>{% if not forloop.last %} · {% endif %}
+						{% endfor %}
+						for {{ grass_seed_duration_in_minutes|floatformat:"-2" }} min
+					</p>
+				</div>
+
+				{% if actuators %}
+				<div class="table-wrap">
+					<table class="dashboard-table">
+						<thead>
+							<tr>
+								<th>Zone</th>
+								<th>Status</th>
+								<th>Next runs</th>
+								<th>Duration</th>
+								<th>Action</th>
+							</tr>
+						</thead>
+						<tbody>
+							{% for actuator in actuators %}
+							<tr>
+								<td>{{ actuator.name }}</td>
+								<td>
+									{% if actuator.grass_seed_mode %}
+									<span class="status-badge status-enabled">Enabled</span>
+									{% else %}
+									<span class="status-badge status-disabled">Off</span>
+									{% endif %}
+								</td>
+								<td>
+									<div class="run-window-list">
+										{% for run_datetime in grass_seed_run_datetimes %}
+										<time datetime="{{ run_datetime|date:"c" }}" data-dashboard-format="weekday-time">{{ run_datetime|date:"l, g:i A" }}</time>
+										{% endfor %}
+									</div>
+								</td>
+								<td>{{ grass_seed_duration_in_minutes|floatformat:"-2" }} min</td>
+								<td>
+									<form class="inline-action-form" action="{% url 'grass_seed_mode_toggle' actuator.id %}" method="post">
+										{% csrf_token %}
+										{% if actuator.grass_seed_mode %}
+										<input type="hidden" name="enabled" value="false">
+										<button class="toggle-button toggle-button-secondary" type="submit">Turn off</button>
+										{% else %}
+										<input type="hidden" name="enabled" value="true">
+										<button class="toggle-button" type="submit">Turn on</button>
+										{% endif %}
+									</form>
+								</td>
+							</tr>
+							{% endfor %}
+						</tbody>
+					</table>
+				</div>
+				{% else %}
+				<p class="empty-state">No zones are configured.</p>
+				{% endif %}
 			</section>
 
 			<section class="dashboard-section" aria-labelledby="queued-title">

--- a/ruta/irrigate/tests/test_schedule.py
+++ b/ruta/irrigate/tests/test_schedule.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from freezegun import freeze_time
 
 from irrigate.models import Actuator, ActuatorRunLog, Device, ScheduleTime
-from irrigate.schedule import run_all
+from irrigate.schedule import GRASS_SEED_DURATION_SECONDS, run_all
 
 
 class ScheduleTests(TestCase):
@@ -76,3 +76,20 @@ class ScheduleTests(TestCase):
     def test_run_all_no_times(self, mock_run):
         run_all()
         mock_run.assert_not_called()
+
+    @patch("irrigate.schedule.emit")
+    @patch("irrigate.schedule._run")
+    def test_run_all_grass_seed_mode_runs_at_evening_hour(self, mock_run, mock_emit):
+        mock_run.return_value = GRASS_SEED_DURATION_SECONDS
+        self.actuator.grass_seed_mode = True
+        self.actuator.save()
+
+        with freeze_time("2021-06-01 00:01:00+00:00"):
+            actuators_that_ran = run_all()
+
+        self.assertEqual(actuators_that_ran, [self.actuator])
+        mock_run.assert_called_once_with(
+            self.actuator,
+            schedule_time=ScheduleTime.objects.get(),
+            duration_override=GRASS_SEED_DURATION_SECONDS,
+        )

--- a/ruta/irrigate/tests/test_views.py
+++ b/ruta/irrigate/tests/test_views.py
@@ -24,6 +24,16 @@ class DashboardAuthTests(TestCase):
             response, f"{reverse('login')}?next={reverse('one_off_run')}"
         )
 
+    def test_grass_seed_mode_toggle_requires_login(self):
+        response = self.client.post(
+            reverse("grass_seed_mode_toggle", args=[1]), {"enabled": "true"}
+        )
+
+        self.assertRedirects(
+            response,
+            f"{reverse('login')}?next={reverse('grass_seed_mode_toggle', args=[1])}",
+        )
+
     def test_dashboard_renders_for_authenticated_user(self):
         user = get_user_model().objects.create_user(
             username="ruta", password="correct-password"
@@ -142,6 +152,55 @@ class DashboardTests(TestCase):
         self.assertContains(response, 'data-dashboard-format="datetime"')
         self.assertContains(response, 'data-dashboard-format="weekday"')
         self.assertContains(response, 'data-dashboard-format="time"')
+
+    @freeze_time("2021-05-31 09:55:00+00:00")
+    def test_dashboard_includes_grass_seed_mode_details(self):
+        grass_seed_actuator = Actuator.objects.create(
+            name="Back Yard",
+            gpio_pin=6,
+            device=self.device,
+            grass_seed_mode=True,
+        )
+
+        response = self.client.get(reverse("dashboard"))
+
+        self.assertEqual(
+            list(response.context["actuators"]), [grass_seed_actuator, self.actuator]
+        )
+        self.assertEqual(response.context["grass_seed_enabled_count"], 1)
+        self.assertEqual(response.context["grass_seed_duration_in_minutes"], 5)
+        self.assertEqual(
+            [
+                run_datetime.isoformat()
+                for run_datetime in response.context["grass_seed_run_datetimes"]
+            ],
+            ["2021-05-31T10:00:00+00:00", "2021-06-01T00:00:00+00:00"],
+        )
+        self.assertContains(response, "Grass seed mode")
+        self.assertContains(response, "Back Yard")
+        self.assertContains(response, "Front Yard")
+        self.assertContains(response, "Turn off")
+        self.assertContains(response, "Turn on")
+        self.assertContains(response, 'data-dashboard-format="weekday-time"')
+
+    def test_grass_seed_mode_toggle_updates_actuator(self):
+        response = self.client.post(
+            reverse("grass_seed_mode_toggle", args=[self.actuator.id]),
+            {"enabled": "true"},
+        )
+
+        self.assertRedirects(response, reverse("dashboard"))
+        self.actuator.refresh_from_db()
+        self.assertTrue(self.actuator.grass_seed_mode)
+
+        response = self.client.post(
+            reverse("grass_seed_mode_toggle", args=[self.actuator.id]),
+            {"enabled": "false"},
+        )
+
+        self.assertRedirects(response, reverse("dashboard"))
+        self.actuator.refresh_from_db()
+        self.assertFalse(self.actuator.grass_seed_mode)
 
     def test_one_off_run_post_creates_queued_schedule(self):
         response = self.client.post(

--- a/ruta/irrigate/urls.py
+++ b/ruta/irrigate/urls.py
@@ -4,5 +4,10 @@ from irrigate import views
 
 urlpatterns = [
     path("", views.DashboardView.as_view(), name="dashboard"),
+    path(
+        "actuators/<int:pk>/grass-seed-mode/",
+        views.GrassSeedModeToggleView.as_view(),
+        name="grass_seed_mode_toggle",
+    ),
     path("runs/one-off/", views.OneOffRunView.as_view(), name="one_off_run"),
 ]

--- a/ruta/irrigate/views.py
+++ b/ruta/irrigate/views.py
@@ -2,12 +2,13 @@ from datetime import datetime, timedelta
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.shortcuts import redirect
+from django.shortcuts import get_object_or_404, redirect
 from django.utils import timezone
 from django.views import generic
 
 from irrigate.forms import OneOffRunForm
-from irrigate.models import ActuatorRunLog, ScheduleTime
+from irrigate.models import Actuator, ActuatorRunLog, ScheduleTime
+from irrigate.schedule import GRASS_SEED_DURATION_SECONDS, GRASS_SEED_RUN_HOURS
 
 
 class DashboardView(LoginRequiredMixin, generic.ListView):
@@ -56,13 +57,20 @@ class DashboardView(LoginRequiredMixin, generic.ListView):
                 now=now,
                 future=True,
             )
+        actuators = list(Actuator.objects.select_related("device").order_by("name"))
 
         context.update(
             {
+                "actuators": actuators,
                 "one_off_form": OneOffRunForm(),
                 "running_runs": running_runs,
                 "queued_one_offs": queued_one_offs,
                 "recurring_schedules": recurring_schedules,
+                "grass_seed_enabled_count": sum(
+                    1 for actuator in actuators if actuator.grass_seed_mode
+                ),
+                "grass_seed_run_datetimes": self._get_grass_seed_run_datetimes(now),
+                "grass_seed_duration_in_minutes": GRASS_SEED_DURATION_SECONDS / 60,
                 "recent_run": ActuatorRunLog.objects.select_related(
                     "actuator", "schedule_time"
                 ).first(),
@@ -89,6 +97,16 @@ class DashboardView(LoginRequiredMixin, generic.ListView):
         if not future and scheduled_datetime > now:
             return scheduled_datetime - timedelta(days=7)
         return scheduled_datetime
+
+    def _get_grass_seed_run_datetimes(self, now):
+        run_datetimes = []
+        for hour in GRASS_SEED_RUN_HOURS:
+            run_datetime = now.replace(hour=hour, minute=0, second=0, microsecond=0)
+            if run_datetime <= now:
+                run_datetime += timedelta(days=1)
+            run_datetimes.append(run_datetime)
+
+        return sorted(run_datetimes)
 
     def _get_next_recurring_schedule(self, recurring_schedules):
         if not recurring_schedules:
@@ -131,4 +149,19 @@ class OneOffRunView(LoginRequiredMixin, generic.View):
                 for error in errors:
                     messages.error(request, error)
 
+        return redirect("dashboard")
+
+
+class GrassSeedModeToggleView(LoginRequiredMixin, generic.View):
+    http_method_names = ["post"]
+
+    def post(self, request, *args, **kwargs):
+        actuator = get_object_or_404(Actuator, pk=kwargs["pk"])
+        actuator.grass_seed_mode = request.POST.get("enabled") == "true"
+        actuator.save(update_fields=["grass_seed_mode"])
+
+        status_label = "enabled" if actuator.grass_seed_mode else "disabled"
+        messages.success(
+            request, f"Grass seed mode {status_label} for {actuator.name}."
+        )
         return redirect("dashboard")


### PR DESCRIPTION
## Summary

- Add a dashboard grass seed mode section that shows all zones, enabled/off status, upcoming run windows, duration, and on/off controls.
- Add a protected POST endpoint for toggling `grass_seed_mode` from the main UI.
- Reuse the dashboard local-time `<time>` formatting for grass seed run windows.
- Normalize the evening grass seed scheduler hour from `24` to `0` so the evening window can actually match Python's `datetime.hour` values.

## Impact

Grass seed mode can now be reviewed and changed from `/` without opening Django admin. The dashboard shows which sprinkler zones have grass seed mode enabled, when the next grass seed runs are scheduled, and how long each run lasts.

## Validation

- `RUTA_SECRET_KEY=test-secret python manage.py test irrigate`